### PR TITLE
Fix/resolve weekday display issue in DayForecast component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.6.5",
+        "luxon": "^3.6.1",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -12884,6 +12885,15 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.6.5",
+    "luxon": "^3.6.1",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/DaysForecast/Components/DayForecast.jsx
+++ b/src/components/DaysForecast/Components/DayForecast.jsx
@@ -2,13 +2,14 @@ import React from "react"
 import PropTypes from 'prop-types'
 import { Box } from '@mui/material'
 import styles from '../styles.module.css'
+import { DateTime } from 'luxon'
 
-const DAYS_OF_THE_WEEK = ['Saturday','Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday']
+const DAYS_OF_THE_WEEK = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
 
 export function DayForecast({ date, icon, minTemp, maxTemp, chanceOfRain }) {
-    const dateForecast = new Date(date)
-    const dayOfTheWeek = dateForecast.getUTCDay()
-    const dayOfMonth = dateForecast.getDate()
+    const dateForecast = DateTime.fromISO(date, { zone: "America/Sao_Paulo" })
+    const dayOfTheWeek = dateForecast.weekday % 7
+    const dayOfMonth = dateForecast.day
 
     const currentDate = new Date()
     const currentDay = currentDate.getDate()


### PR DESCRIPTION
- Add luxon dependency for proper date handling
- Fix weekday calculation using DateTime.weekday
- Ensure all three days of the week are displayed correctly
- Replace native Date handling with luxon for timezone support