### PR TITLE
Fix/resolve layout inconsistencies in DayForecast component

### DIFF
--- a/src/components/DaysForecast/Components/DayForecast.jsx
+++ b/src/components/DaysForecast/Components/DayForecast.jsx
@@ -13,7 +13,7 @@ export function DayForecast({ date, icon, minTemp, maxTemp, chanceOfRain }) {
     const currentDate = new Date()
     const currentDay = currentDate.getDate()
 
-    return currentDay <= dayOfMonth? (
+    return currentDay <= dayOfMonth ? (
         <Box
             display="flex"
             gap={2}
@@ -21,27 +21,27 @@ export function DayForecast({ date, icon, minTemp, maxTemp, chanceOfRain }) {
             alignItems="center"
         >
             <Box width="120px">
-                {dayOfMonth === currentDay ? 'Today' : DAYS_OF_THE_WEEK[dayOfTheWeek] + ", "+ dayOfMonth}
+                {dayOfMonth === currentDay ? 'Today' : DAYS_OF_THE_WEEK[dayOfTheWeek] + ", " + dayOfMonth}
             </Box>
             
             <Box className={styles.rowChanceOfRain}>
                 <img src={icon} width="30px" alt="Icon" />
-
-                { chanceOfRain > 0 ? (
-                    <Box className={styles.labelChanceOfRain}>
-                        { chanceOfRain }%
-                    </Box>
-                ) : '' }
+                <Box className={styles.labelChanceOfRain}>
+                    {chanceOfRain}%
+                </Box>
             </Box>
-
+            
             <Box display="flex" alignItems="center">
-                { minTemp }º
-                <hr className={styles.linhaMinMaxTemp}></hr>
-                { maxTemp }º
+                <Box width="30px" textAlign="right">
+                    {minTemp}º
+                </Box>
+                <hr className={styles.linhaMinMaxTemp} />
+                <Box width="30px" textAlign="left">
+                    {maxTemp}º
+                </Box>
             </Box>
-
         </Box>
-    ):""
+    ) : ""
 }
 
 DayForecast.propTypes = {


### PR DESCRIPTION
Fixes layout jumping when switching between cities with different temperature ranges and rain probability values.
- Always display rain chance percentage (including 0%) to maintain consistent sizing
- Add fixed width containers for temperature values to prevent layout shifts
- Improve code formatting and organization for better readability